### PR TITLE
Protect Sollet integration from the clutches of Vue's reactivity primitives.

### DIFF
--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -20,7 +20,7 @@
         </span>
         <span v-else>
             <input type="radio" id="sollet-rad" value="sollet" v-model="walletChoice"/>
-            <label for="sollet-rad">sollet (this probably doesnt work)</label>
+            <label for="sollet-rad">sollet</label>
             <input type="radio" id="phantom-rad" value="phantom" v-model="walletChoice"/>
             <label for="phantom-rad">phantom</label>
         </span>
@@ -133,6 +133,7 @@ import * as w3 from "@solana/web3.js";
 import { TOKEN_PROGRAM_ID, Token, AccountLayout, u64 } from "@solana/spl-token";
 import { PhantomWalletAdapter } from "@solana/wallet-adapter-phantom";
 import { SolletWalletAdapter } from "@solana/wallet-adapter-sollet";
+import { shallowRef } from 'vue';
 import Dots from "./Dots.vue";
 import Address from "./Address.vue";
 
@@ -156,7 +157,7 @@ export default {
     data() {
         return {
             connection: null,
-            wallet: null,
+            wallet: shallowRef(null),
             walletConnected: false,
             walletChoice: "phantom",
             solBalance: null,


### PR DESCRIPTION
Long explanation of how and why Vue's reactivity primitives were breaking Sollet integration: https://twitter.com/steveluscher/status/1453983387648073732

Using `shallowRef` is like saying ‘OK, listen; you can track the fact of the `wallet` having been set or unset, but don't track all of its properties recursively.’

https://user-images.githubusercontent.com/13243/139519672-60146327-1b78-4420-8389-4e5699db047c.mov

