### PR TITLE
fix: delete hana-tweet.png to fix missing git-lfs file issue

### DIFF
--- a/public/hana-tweet.png
+++ b/public/hana-tweet.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bcf25b62cb5f000932772b622025aed96fb98d7f9692d4675da6f5f33b487f58
-size 32033


### PR DESCRIPTION
fixes #2

I don't think this image is being used now, this should hopefully remove the warning